### PR TITLE
Support unwind-rs as alternative unwinder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ rust:
 
 script:
   - cargo test
+  - cargo test --features unwinder_unwind_rs --no-default-features
   - cargo run --example simple || true
+  - cargo run --example simple --features unwinder_unwind_rs --no-default-features || true
 
 env:
 - RUST_BACKTRACE=pretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ rust:
 
 script:
   - cargo test
-  - cargo test --features unwinder_unwind_rs --no-default-features
   - cargo run --example simple || true
-  - cargo run --example simple --features unwinder_unwind_rs --no-default-features || true
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+    cargo test --features unwinder_unwind_rs --no-default-features;
+    cargo run --example simple --features unwinder_unwind_rs --no-default-features || true;
+    fi
 
 env:
 - RUST_BACKTRACE=pretty

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ gimli = "0.18.0"
 addr2line = "0.9.0"
 
 backtrace = "0.3.13"
+unwind = { git = "https://github.com/gimli-rs/unwind-rs.git", optional = true }
 
 regex = "1.1.0"
 lazy_static = "1.2.0"
@@ -24,3 +25,9 @@ syntect = "3.0.2"
 rental = "0.5.2"
 findshlibs = "0.4.0"
 libc = "0.2.51"
+fallible-iterator = "0.1.0"
+
+[features]
+default = ["unwinder_backtrace"]
+unwinder_backtrace = []
+unwinder_unwind_rs = ["unwind"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ gimli = "0.18.0"
 addr2line = "0.9.0"
 
 backtrace = "0.3.13"
-unwind = { git = "https://github.com/gimli-rs/unwind-rs.git", optional = true }
 
 regex = "1.1.0"
 lazy_static = "1.2.0"
@@ -26,6 +25,11 @@ rental = "0.5.2"
 findshlibs = "0.4.0"
 libc = "0.2.51"
 fallible-iterator = "0.1.0"
+
+[dependencies.unwind]
+git = "https://github.com/gimli-rs/unwind-rs.git"
+optional = true
+default-features = false # Disable libunwind shim
 
 [features]
 default = ["unwinder_backtrace"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ fallible-iterator = "0.1.0"
 [dependencies.unwind]
 git = "https://github.com/gimli-rs/unwind-rs.git"
 optional = true
+rev = "39a0642651041da397558e7d41bd699e4b0706dc"
 default-features = false # Disable libunwind shim
 
 [features]

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -2,20 +2,15 @@ use findshlibs::Avma;
 
 use crate::{Address, Frame, FrameIndex};
 
+#[cfg(feature = "unwinder_backtrace")]
 pub fn print_backtrace() {
     let context = crate::locate_debuginfo::get_context();
 
     let backtrace = backtrace::Backtrace::new_unresolved();
     for (i, stack_frame) in backtrace.frames().iter().enumerate().map(|(i, frame)| (FrameIndex(i), frame)) {
-        let addr = if let Some(addr) = Address::from_avma(Avma(stack_frame.ip() as *const u8)) {
+        let addr = if let Some(addr) = ip_to_address(stack_frame.ip() as *const u8, i) {
             addr
         } else {
-            if stack_frame.ip() as usize == 0 {
-                eprintln!("{} \x1b[2m<end of stack> (0)\x1b[0m", i);
-            } else {
-                eprintln!("{} \x1b[91m<could not get svma> ({:016p})\x1b[0m", i, stack_frame.ip());
-            }
-
             continue;
         };
 
@@ -24,10 +19,59 @@ pub fn print_backtrace() {
             addr,
         });
 
-        // Wait a second each 100 frames to prevent filling the screen in case of a stackoverflow
-        if i.0 % 100 == 99 {
-            eprintln!("Backtrace is very big, sleeping 1s...");
-            std::thread::sleep_ms(1000);
+        stackoverflow_wait(i);
+    }
+}
+
+#[cfg(feature = "unwinder_unwind_rs")]
+pub fn print_backtrace() {
+    use unwind::Unwinder;
+    use fallible_iterator::FallibleIterator;
+
+    let context = crate::locate_debuginfo::get_context();
+
+    unwind::DwarfUnwinder::default().trace(|x| {
+        let mut i = FrameIndex(0);
+        while let Some(frame) = x.next().unwrap() {
+            let ip = x.registers()[16].unwrap();
+
+            let addr = if let Some(addr) = ip_to_address(ip as *const u8, i) {
+                addr
+            } else {
+                continue;
+            };
+
+            crate::display_frame::display_frame(&context, Frame {
+                index: i,
+                addr,
+                regs: x.registers().clone(),
+            });
+
+            stackoverflow_wait(i);
+
+            i.0 += 1;
         }
+    });
+}
+
+fn ip_to_address(ip: *const u8, i: FrameIndex) -> Option<Address> {
+    if let Some(addr) = Address::from_avma(Avma(ip)) {
+        Some(addr)
+    } else {
+        if ip as usize == 0 {
+            eprintln!("{} \x1b[2m<end of stack> (0)\x1b[0m", i);
+        } else {
+            eprintln!("{} \x1b[91m<could not get svma> ({:016p})\x1b[0m", i, ip);
+        }
+
+        None
+    }
+}
+
+fn stackoverflow_wait(i: FrameIndex) {
+    // Wait a second each 100 frames to prevent filling the screen in case of a stackoverflow
+    if i.0 % 100 == 99 {
+        eprintln!("Backtrace is very big, sleeping 1s...");
+        std::thread::sleep_ms(1000);
     }
 }

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -32,7 +32,7 @@ pub fn print_backtrace() {
 
     unwind::DwarfUnwinder::default().trace(|x| {
         let mut i = FrameIndex(0);
-        while let Some(frame) = x.next().unwrap() {
+        while let Some(_frame) = x.next().unwrap() {
             let ip = x.registers()[16].unwrap();
 
             let addr = if let Some(addr) = ip_to_address(ip as *const u8, i) {
@@ -72,6 +72,6 @@ fn stackoverflow_wait(i: FrameIndex) {
     // Wait a second each 100 frames to prevent filling the screen in case of a stackoverflow
     if i.0 % 100 == 99 {
         eprintln!("Backtrace is very big, sleeping 1s...");
-        std::thread::sleep_ms(1000);
+        std::thread::sleep(std::time::Duration::from_secs(1));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,9 @@ impl fmt::Display for FrameIndex {
 struct Frame {
     index: FrameIndex,
     addr: Address,
+    #[cfg(feature = "unwinder_unwind_rs")]
+    regs: unwind::Registers,
 }
-
 
 #[derive(Clone)]
 struct Address {


### PR DESCRIPTION
This is necessary for #1, as `backtrace-rs` doesn't support getting register values.